### PR TITLE
Bug/inactive tab race condition

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Ethereum Gas Price Extension",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Displays the current gas price provided by EthGasStation",
   "manifest_version": 2,
   "background": {

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -20,7 +20,7 @@ function updateBadge() {
 }
 
 function fetchGasPrice() {
-  fetch("https://ethgasstation.info/json/ethgasAPI.json")
+  return fetch("https://ethgasstation.info/json/ethgasAPI.json")
     .then((res) => {return res.json()})
     .then(data => {
       // Store the current data for the popup page

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,6 +5,7 @@
 <html>
   <body>
   	<div class="popup js-popup">
+  		Fetching gas prices...
   	</div>
   	<div class="info">
   		Data provided by <a href="https://ethgasstation.info" target="_blank">ETH Gas Station</a>

--- a/src/style.css
+++ b/src/style.css
@@ -7,7 +7,7 @@ body {
 
 .popup {
 	display: flex;
-	
+	height: 65px;
 }
 
 .info {


### PR DESCRIPTION
Fixes a bug where if the event page was inactive, sometimes clicking the icon showed "NaN" for the gas prices, since it hasn't fetched the gas prices data yet. This makes sure if there's no data there, we fetch the gas price data first.